### PR TITLE
Add Spotify login and personality card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,21 @@
-<<<<<<< HEAD
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Talking Sounds
 
-## Getting Started
+Talking Sounds is a small demo web app that connects with your Spotify account and builds a short music personality card based on your top artists and tracks. The app is built with **Next.js**, **Tailwind CSS** and uses the **Spotify Web API**.
 
-First, run the development server:
+## Development
 
-```bash
+```
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Set the environment variables `NEXT_PUBLIC_SPOTIFY_CLIENT_ID` and `NEXT_PUBLIC_SPOTIFY_REDIRECT_URI` in a `.env.local` file. The redirect URI must match the one configured in your Spotify developer dashboard.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Features
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- Login with Spotify (OAuth implicit flow)
+- Fetch top artists and tracks
+- Simple rule-based personality assignment
+- Downloadable card preview
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-=======
-# talking_sounds
-talking sounds is a web app that turns your spotify data into a unique audio personality card.
-connect your account, get matched to one of the 16 music-based identities and see everything visualized on a stylish,
-double-sided card: front with your type, back with an interactive vinyl chart.
-
-!! no data is stored. fully responsive. ready to share. !!
+No data is stored on the server. Everything happens in-memory in the browser.

--- a/src/app/api/spotify/top/route.ts
+++ b/src/app/api/spotify/top/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const token = req.headers.get('authorization');
+  if (!token) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const type = searchParams.get('type') ?? 'artists';
+
+  const res = await fetch(`https://api.spotify.com/v1/me/top/${type}?time_range=short_term&limit=10`, {
+    headers: {
+      Authorization: token,
+    },
+  });
+
+  if (!res.ok) {
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/src/app/callback/page.tsx
+++ b/src/app/callback/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function Callback() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const hash = window.location.hash.substring(1);
+    const params = new URLSearchParams(hash);
+    const accessToken = params.get('access_token');
+    if (accessToken) {
+      sessionStorage.setItem('access_token', accessToken);
+      router.push('/dashboard');
+    }
+  }, [router]);
+
+  return (
+    <main className="flex h-screen items-center justify-center">
+      Returning from Spotify...
+    </main>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { useEffect, useState } from 'react';
+import PersonalityCard from '@/components/PersonalityCard';
+
+interface Artist {
+  name: string;
+  popularity: number;
+  genres: string[];
+}
+
+interface Track {
+  name: string;
+  artists: { name: string }[];
+}
+
+export default function Dashboard() {
+  const [artists, setArtists] = useState<Artist[]>([]);
+  const [tracks, setTracks] = useState<Track[]>([]);
+
+  useEffect(() => {
+    const token = sessionStorage.getItem('access_token');
+    if (!token) return;
+
+    fetch('/api/spotify/top?type=artists', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => res.json())
+      .then((data) => setArtists(data.items || []));
+
+    fetch('/api/spotify/top?type=tracks', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => res.json())
+      .then((data) => setTracks(data.items || []));
+  }, []);
+
+  if (!artists.length || !tracks.length) {
+    return (
+      <main className="flex h-screen items-center justify-center">
+        Loading your music data...
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-8 p-6">
+      <PersonalityCard artists={artists} tracks={tracks} />
+    </main>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+import { useEffect } from 'react';
+
+export default function Login() {
+  const SPOTIFY_CLIENT_ID = process.env.NEXT_PUBLIC_SPOTIFY_CLIENT_ID as string;
+  const REDIRECT_URI = process.env.NEXT_PUBLIC_SPOTIFY_REDIRECT_URI as string;
+
+  const login = () => {
+    const scopes = ['user-top-read'];
+    const params = new URLSearchParams({
+      response_type: 'token',
+      client_id: SPOTIFY_CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      scope: scopes.join(' '),
+    });
+    window.location.href = `https://accounts.spotify.com/authorize?${params.toString()}`;
+  };
+
+  return (
+    <main className="flex h-screen flex-col items-center justify-center gap-4">
+      <button
+        className="rounded bg-green-500 px-6 py-3 font-bold text-white hover:bg-green-600"
+        onClick={login}
+      >
+        Login with Spotify
+      </button>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,12 @@
+import Link from 'next/link';
+
 export default function Home() {
   return (
-    <main className="font-poppins flex h-screen items-center justify-center bg-white text-black text-4xl">
-      🌀 welcome to talking sounds! are you ready to get to know yourself?
+    <main className="font-poppins flex h-screen flex-col items-center justify-center gap-6 bg-white text-black">
+      <p className="text-4xl">🌀 welcome to talking sounds! ready to discover your music self?</p>
+      <Link href="/login" className="rounded bg-green-500 px-6 py-3 text-lg font-semibold text-white hover:bg-green-600">
+        Login with Spotify
+      </Link>
     </main>
-  )
+  );
 }

--- a/src/components/PersonalityCard.tsx
+++ b/src/components/PersonalityCard.tsx
@@ -1,0 +1,63 @@
+"use client";
+import html2canvas from 'html2canvas';
+import { useMemo, useRef } from 'react';
+
+interface Artist {
+  name: string;
+  popularity: number;
+  genres: string[];
+}
+
+interface Track {
+  name: string;
+  artists: { name: string }[];
+}
+
+interface Props {
+  artists: Artist[];
+  tracks: Track[];
+}
+
+function mapToPersonality(artists: Artist[], tracks: Track[]) {
+  // very naive scoring for demo
+  const avgPopularity =
+    artists.reduce((sum, a) => sum + a.popularity, 0) / artists.length;
+  if (avgPopularity > 70) return 'The Trendsetter';
+  if (avgPopularity > 50) return 'The Explorer';
+  return 'The Rebel';
+}
+
+export default function PersonalityCard({ artists, tracks }: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const personality = useMemo(
+    () => mapToPersonality(artists, tracks),
+    [artists, tracks]
+  );
+
+  const download = async () => {
+    if (!cardRef.current) return;
+    const canvas = await html2canvas(cardRef.current);
+    const link = document.createElement('a');
+    link.download = 'personality-card.png';
+    link.href = canvas.toDataURL();
+    link.click();
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div
+        ref={cardRef}
+        className="w-80 rounded-lg border bg-white p-6 text-center shadow"
+      >
+        <h2 className="mb-4 text-2xl font-bold">{personality}</h2>
+        <div className="h-40 w-40 rounded-full border-4 border-dashed border-gray-400" />
+      </div>
+      <button
+        className="rounded bg-blue-600 px-4 py-2 font-semibold text-white"
+        onClick={download}
+      >
+        Download Card
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- rewrite README
- add login page and OAuth callback handler
- fetch top artists and tracks in dashboard
- implement personality card component with simple scoring
- expose API route to query Spotify top data
- update home page with login link

## Testing
- `npm run build` *(fails: next not found)* --> need to fix the bug