### PR TITLE
Add red welcome text to homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6">
+      <h1 className="font-sans text-[#CB1F1F] text-3xl">Willkommen!</h1>
       <Link
         href="/api/spotify/login"
         className="rounded bg-green-600 px-6 py-2 text-white"


### PR DESCRIPTION
## Summary
- show a welcome heading on the start page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fdf273140833294dc414e839ffd03